### PR TITLE
prepare 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.1] - 2018-07-02
+
+### Changed
+- The dependency on `Newtonsoft.JSON` now has a minimum version of 6.0.1 rather than 9.0.1. This should not affect any applications that specify a higher version for this assembly.
+
+### Removed
+- The `Identify` method is no longer part of `ILdCdCommonClient`, since it does not have the same signature in the Xamarin client as in the server-side .NET SDK.
+
 ## [1.0.0] - 2018-06-26
 
 Initial release, corresponding to .net-client version 5.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ For full release notes for the projects that depend on this project, see their r
 ## [1.0.1] - 2018-07-02
 
 ### Changed
-- The dependency on `Newtonsoft.JSON` now has a minimum version of 6.0.1 rather than 9.0.1. This should not affect any applications that specify a higher version for this assembly.
+- When targeting .NET 4.5, the dependency on `Newtonsoft.Json` now has a minimum version of 6.0.1 rather than 9.0.1. This should not affect any applications that specify a higher version for this assembly.
 
 ### Removed
-- The `Identify` method is no longer part of `ILdCdCommonClient`, since it does not have the same signature in the Xamarin client as in the server-side .NET SDK.
+- The `Identify` method is no longer part of `ILdCommonClient`, since it does not have the same signature in the Xamarin client as in the server-side .NET SDK.
 
 ## [1.0.0] - 2018-06-26
 

--- a/src/LaunchDarkly.Common/ILdCommonClient.cs
+++ b/src/LaunchDarkly.Common/ILdCommonClient.cs
@@ -21,12 +21,6 @@ namespace LaunchDarkly.Common
         void Flush();
 
         /// <summary>
-        /// Registers the user.
-        /// </summary>
-        /// <param name="user">the user to register</param>
-        void Identify(User user);
-
-        /// <summary>
         /// Returns the current version number of the LaunchDarkly client.
         /// </summary>
         Version Version { get; }

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.1-beta.1</Version>
+    <Version>1.0.1</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
## [1.0.1] - 2018-07-02

### Changed
- When targeting .NET 4.5, the dependency on `Newtonsoft.Json` now has a minimum version of 6.0.1 rather than 9.0.1. This should not affect any applications that specify a higher version for this assembly.

### Removed
- The `Identify` method is no longer part of `ILdCommonClient`, since it does not have the same signature in the Xamarin client as in the server-side .NET SDK.
