### PR TITLE
prepare 1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.4] - 2018-08-02
+
+### Changed
+- Updated the dependency on `LaunchDarkly.EventSource`, which no longer has package references to System assemblies.
+
 ## [1.0.3] - 2018-07-27
 
 ### Changed

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.2-beta2</Version>
+    <Version>1.0.2</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
## [1.0.4] - 2018-08-02

### Changed
- Updated the dependency on `LaunchDarkly.EventSource`, which no longer has package references to System assemblies.
