### PR TITLE
prepare 1.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.6] - 2018-08-30
+
+### Fixed
+- Updated LaunchDarkly.EventSource to fix a bug that prevented the client from reconnecting to the stream if it received an HTTP error status from the server (as opposed to simply losing the connection).
+
 ## [1.0.5] - 2018-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.5] - 2018-08-14
+
+### Fixed
+- The reconnection attempt counter is no longer shared among all StreamManager instances. Previously, if you connected to more than one stream, all but the first would behave as if they were reconnecting and would have a backoff delay.
+
 ## [1.0.4] - 2018-08-02
 
 ### Changed

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.2-beta2</Version>
+    <Version>1.0.2</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.2" />
+    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'net45'" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.3" />
+    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'net45'" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.2" />
+    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'net45'" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.3" />
+    <PackageReference Include="LaunchDarkly.EventSource" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'net45'" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
The only change here is to bump the LaunchDarkly.EventSource dependency, so I didn't bother with a separate PR for that.